### PR TITLE
Add SEO metadata, structured data, and sitemap

### DIFF
--- a/SEO.md
+++ b/SEO.md
@@ -1,0 +1,26 @@
+# SEO Improvements
+
+## Site Inventory
+- `/` – Programming Languages (public)
+- `/Frameworks` – Frameworks overview (public)
+- `/Frameworks/ToLib` – Tools or Libraries for a framework (public)
+- `/TimeLine` – Programming languages timeline (public)
+- `/developer-essential-skills` – Developer essential skills article (public)
+
+No private or dashboard routes were detected.
+
+## Changes Implemented
+- Added baseline SEO metadata and Organization schema in `index.html`.
+- Created reusable `useSEO` hook to set titles, meta tags, canonical URLs,
+  Open Graph and Twitter Card data, and JSON‑LD structured data per route.
+- Applied `useSEO` to all public pages with unique titles and descriptions.
+- Added `robots.txt` and `sitemap.xml` in `public/`.
+- Added internal link to Frameworks in the footer for better navigation.
+
+## Pending / Future Work
+- Implement server-side rendering or prerendering so crawlers receive fully
+  rendered HTML.
+- Audit and optimise images, code-splitting and other performance tasks for
+  Core Web Vitals.
+- Add blog content and additional structured data as new pages are created.
+- Run Lighthouse, Rich Results Test, and submit sitemap to search consoles.

--- a/index.html
+++ b/index.html
@@ -8,13 +8,32 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
-
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
 
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap"
+  <link
+    href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap"
     rel="stylesheet">
+
+  <meta name="description" content="CodeSphere - guides for programming languages and frameworks." />
+  <link rel="canonical" href="https://codesphere.dev/" />
+  <meta property="og:title" content="CodeSphere" />
+  <meta property="og:description" content="Guides for programming languages, frameworks and developer skills." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://codesphere.dev/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="CodeSphere" />
+  <meta name="twitter:description" content="Guides for programming languages, frameworks and developer skills." />
+
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "CodeSphere",
+      "url": "https://codesphere.dev/"
+    }
+  </script>
 
   <title>CodeSphere</title>
 </head>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://codesphere.dev/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://codesphere.dev/</loc></url>
+  <url><loc>https://codesphere.dev/Frameworks</loc></url>
+  <url><loc>https://codesphere.dev/Frameworks/ToLib</loc></url>
+  <url><loc>https://codesphere.dev/TimeLine</loc></url>
+  <url><loc>https://codesphere.dev/developer-essential-skills</loc></url>
+</urlset>

--- a/src/Components/Footer.jsx
+++ b/src/Components/Footer.jsx
@@ -8,8 +8,6 @@ import toast from "react-hot-toast";
 
 const Footer = () => {
   const [isLoading, setLoading] = useState(false);
-  const [showAlert, setShowAlert] = useState(false);
-  const [isError, setIsError] = useState(false);
   const [feedback, setFeedback] = useState({
     name: "",
     message: "",
@@ -23,7 +21,7 @@ const Footer = () => {
     e.preventDefault();
     setLoading(true);
     try {
-      const response = await axios.post(
+      await axios.post(
         "https://feed-backs.vercel.app/response/add",
         {
           webapp: "codes-sphere",
@@ -57,6 +55,9 @@ const Footer = () => {
           </Link>
           <Link to={"/TimeLine"} className='link link-hover '>
             TimeLine
+          </Link>
+          <Link to={"/Frameworks"} className='link link-hover '>
+            Frameworks
           </Link>
           <Link to={"/developer-essential-skills"} className='link link-hover '>
             Why Matters

--- a/src/Components/Frameworks.jsx
+++ b/src/Components/Frameworks.jsx
@@ -1,12 +1,59 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import Card from "./cards/Card";
 import { Link, useLocation } from "react-router-dom";
-import useScrollRestoration from "./Hooks/ScrollRestoration";
+import useSEO from "./Hooks/useSEO";
 
 const ProgLan = () => {
-  // useScrollRestoration();
   const location = useLocation();
   const { Frameworks } = location.state || { Frameworks: [] };
+
+  useSEO({
+    title: "Frameworks Overview | CodeSphere",
+    description:
+      "Browse popular programming frameworks and tools with summaries and links.",
+    canonical: "https://codesphere.dev/Frameworks",
+    og: {
+      title: "Frameworks Overview | CodeSphere",
+      description:
+        "Browse popular programming frameworks and tools with summaries and links.",
+      url: "https://codesphere.dev/Frameworks",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: "Frameworks Overview | CodeSphere",
+      description:
+        "Browse popular programming frameworks and tools with summaries and links.",
+    },
+    structuredData: {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Service",
+          name: "Frameworks Overview",
+          provider: { "@type": "Organization", name: "CodeSphere" },
+          url: "https://codesphere.dev/Frameworks",
+        },
+        {
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              position: 1,
+              name: "Home",
+              item: "https://codesphere.dev/",
+            },
+            {
+              "@type": "ListItem",
+              position: 2,
+              name: "Frameworks",
+              item: "https://codesphere.dev/Frameworks",
+            },
+          ],
+        },
+      ],
+    },
+  });
 
   useEffect(() => {
     window.scrollTo(0, 0);

--- a/src/Components/Hooks/useSEO.js
+++ b/src/Components/Hooks/useSEO.js
@@ -1,0 +1,55 @@
+import { useEffect } from "react";
+
+const setMeta = (attr, name, content) => {
+  let element = document.head.querySelector(`meta[${attr}="${name}"]`);
+  if (!element) {
+    element = document.createElement("meta");
+    element.setAttribute(attr, name);
+    document.head.appendChild(element);
+  }
+  element.setAttribute("content", content);
+};
+
+const useSEO = ({ title, description, canonical, og = {}, twitter = {}, structuredData }) => {
+  useEffect(() => {
+    if (title) {
+      document.title = title;
+    }
+    if (description) {
+      setMeta("name", "description", description);
+    }
+    if (canonical) {
+      let link = document.head.querySelector("link[rel=\"canonical\"]");
+      if (!link) {
+        link = document.createElement("link");
+        link.setAttribute("rel", "canonical");
+        document.head.appendChild(link);
+      }
+      link.setAttribute("href", canonical);
+    }
+
+    Object.entries(og).forEach(([key, value]) => {
+      setMeta("property", `og:${key}`, value);
+    });
+
+    Object.entries(twitter).forEach(([key, value]) => {
+      setMeta("name", `twitter:${key}`, value);
+    });
+
+    const scriptId = "seo-structured-data";
+    let script = document.getElementById(scriptId);
+    if (structuredData) {
+      if (!script) {
+        script = document.createElement("script");
+        script.id = scriptId;
+        script.type = "application/ld+json";
+        document.head.appendChild(script);
+      }
+      script.textContent = JSON.stringify(structuredData);
+    } else if (script) {
+      script.remove();
+    }
+  }, [title, description, canonical, og, twitter, structuredData]);
+};
+
+export default useSEO;

--- a/src/Components/Languages.jsx
+++ b/src/Components/Languages.jsx
@@ -1,10 +1,34 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import List from "../Data/JS.json";
 import LanCard from "./cards/LanCard";
-import useScrollRestoration from "./Hooks/ScrollRestoration";
+import useSEO from "./Hooks/useSEO";
 
 const Languages = () => {
-  // useScrollRestoration();
+  useSEO({
+    title: "Programming Languages Guide | CodeSphere",
+    description:
+      "Explore programming languages, their summaries and key details at CodeSphere.",
+    canonical: "https://codesphere.dev/",
+    og: {
+      title: "Programming Languages Guide | CodeSphere",
+      description:
+        "Explore programming languages, their summaries and key details at CodeSphere.",
+      url: "https://codesphere.dev/",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: "Programming Languages Guide | CodeSphere",
+      description:
+        "Explore programming languages, their summaries and key details at CodeSphere.",
+    },
+    structuredData: {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      name: "Programming Languages Guide",
+      url: "https://codesphere.dev/",
+    },
+  });
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "instant" });

--- a/src/Components/TimeLine.jsx
+++ b/src/Components/TimeLine.jsx
@@ -1,17 +1,60 @@
 import languagesTimeLine from "../Data/TimeLine.js";
-import { MdCircle } from "react-icons/md";
-import Footer from "./Footer.jsx";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useInView } from "motion/react";
-import { useRef } from "react";
 import TimeLineCard from "./cards/TimeLine/TimeLineCard.jsx";
 import Line from "./cards/TimeLine/Line.jsx";
-import useScrollRestoration from "./Hooks/ScrollRestoration.jsx";
+import useSEO from "./Hooks/useSEO";
 
 const TimeLine = () => {
-  // useScrollRestoration();
   const ref = useRef();
   const isInView = useInView(ref, { once: true });
+
+  useSEO({
+    title: "Programming Languages Timeline | CodeSphere",
+    description:
+      "Chronological timeline showcasing the evolution of programming languages.",
+    canonical: "https://codesphere.dev/TimeLine",
+    og: {
+      title: "Programming Languages Timeline | CodeSphere",
+      description:
+        "Chronological timeline showcasing the evolution of programming languages.",
+      url: "https://codesphere.dev/TimeLine",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: "Programming Languages Timeline | CodeSphere",
+      description:
+        "Chronological timeline showcasing the evolution of programming languages.",
+    },
+    structuredData: {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Article",
+          name: "Programming Languages Timeline",
+          url: "https://codesphere.dev/TimeLine",
+        },
+        {
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              position: 1,
+              name: "Home",
+              item: "https://codesphere.dev/",
+            },
+            {
+              "@type": "ListItem",
+              position: 2,
+              name: "Timeline",
+              item: "https://codesphere.dev/TimeLine",
+            },
+          ],
+        },
+      ],
+    },
+  });
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "instant" });

--- a/src/Components/Tool_Lib.jsx
+++ b/src/Components/Tool_Lib.jsx
@@ -1,6 +1,6 @@
-import React from "react";
 import Tool_Lib_Card from "./cards/Tool_Lib_Card";
 import { useLocation, Link } from "react-router-dom";
+import useSEO from "./Hooks/useSEO";
 
 const Tool_Lib = () => {
   const location = useLocation();
@@ -14,6 +14,7 @@ const Tool_Lib = () => {
   let printIt = [];
   let heading = "";
   let def = "";
+  let crumbName = "";
 
   const toolDef =
     "Framework tools are software frameworks that provide developers with a structured foundation and pre-built components to build applications more efficiently. These tools often include libraries, templates, and best practices that streamline the development process.";
@@ -25,11 +26,64 @@ const Tool_Lib = () => {
     printIt = tools;
     heading = "Tools";
     def = toolDef;
+    crumbName = "Tools";
   } else {
     printIt = Libraries;
     heading = "Libraries";
     def = libDef;
+    crumbName = "Libraries";
   }
+
+  useSEO({
+    title: `${heading} for Frameworks | CodeSphere`,
+    description: def,
+    canonical: "https://codesphere.dev/Frameworks/ToLib",
+    og: {
+      title: `${heading} for Frameworks | CodeSphere`,
+      description: def,
+      url: "https://codesphere.dev/Frameworks/ToLib",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${heading} for Frameworks | CodeSphere`,
+      description: def,
+    },
+    structuredData: {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Service",
+          name: `${heading} for Frameworks`,
+          provider: { "@type": "Organization", name: "CodeSphere" },
+          url: "https://codesphere.dev/Frameworks/ToLib",
+        },
+        {
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              position: 1,
+              name: "Home",
+              item: "https://codesphere.dev/",
+            },
+            {
+              "@type": "ListItem",
+              position: 2,
+              name: "Frameworks",
+              item: "https://codesphere.dev/Frameworks",
+            },
+            {
+              "@type": "ListItem",
+              position: 3,
+              name: crumbName,
+              item: "https://codesphere.dev/Frameworks/ToLib",
+            },
+          ],
+        },
+      ],
+    },
+  });
 
   return (
     <>

--- a/src/Components/VersionControl.jsx
+++ b/src/Components/VersionControl.jsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+/* eslint-disable react/prop-types */
 import { useEffect } from "react";
-import useScrollRestoration from "./Hooks/ScrollRestoration";
+import useSEO from "./Hooks/useSEO";
 
 const AccordionItem = ({ title, content }) => (
   <div className='collapse  join-item border-b border-base-200'>
@@ -13,8 +13,52 @@ const AccordionItem = ({ title, content }) => (
 );
 
 const AccordionGroup = () => {
-  // useScrollRestoration();
-  const [openIndex, setOpenIndex] = useState(0);
+  useSEO({
+    title: "Developer Essential Skills | CodeSphere",
+    description:
+      "Key questions highlighting why core developer skills like version control, testing and design patterns matter.",
+    canonical: "https://codesphere.dev/developer-essential-skills",
+    og: {
+      title: "Developer Essential Skills | CodeSphere",
+      description:
+        "Key questions highlighting why core developer skills like version control, testing and design patterns matter.",
+      url: "https://codesphere.dev/developer-essential-skills",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: "Developer Essential Skills | CodeSphere",
+      description:
+        "Key questions highlighting why core developer skills like version control, testing and design patterns matter.",
+    },
+    structuredData: {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Article",
+          name: "Developer Essential Skills",
+          url: "https://codesphere.dev/developer-essential-skills",
+        },
+        {
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              position: 1,
+              name: "Home",
+              item: "https://codesphere.dev/",
+            },
+            {
+              "@type": "ListItem",
+              position: 2,
+              name: "Developer Essential Skills",
+              item: "https://codesphere.dev/developer-essential-skills",
+            },
+          ],
+        },
+      ],
+    },
+  });
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "instant" });
@@ -163,7 +207,6 @@ const AccordionGroup = () => {
               key={index}
               title={item.title}
               content={item.content}
-              onClick={() => setOpenIndex(index)}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- add global meta tags and Organization JSON-LD
- create reusable useSEO hook for per-route metadata and structured data
- include robots.txt, sitemap.xml, and footer link to Frameworks
- document SEO work and future improvements

## Testing
- `npx eslint src/Components/Languages.jsx src/Components/Frameworks.jsx src/Components/Tool_Lib.jsx src/Components/TimeLine.jsx src/Components/VersionControl.jsx src/Components/Footer.jsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6d086c0a0832bac97fe3a23380fd4