### PR TITLE
Handle direct visits to frameworks page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,9 +16,7 @@ import { Toaster } from "react-hot-toast";
 
 const Layout = () => {
   const location = useLocation();
-  const hideFooter = ["/Frameworks/ToLib", "/Frameworks"].includes(
-    location.pathname
-  );
+  const hideFooter = location.pathname.startsWith("/Frameworks");
 
   return (
     <>
@@ -26,7 +24,10 @@ const Layout = () => {
       <Routes>
         <Route path='/' element={<Languages />} />
         <Route path='/Frameworks' element={<Frameworks />} />
-        <Route path='/Frameworks/ToLib' element={<Tool_Lib />} />
+        <Route
+          path='/Frameworks/:frameworkName/:type'
+          element={<Tool_Lib />}
+        />
         <Route path='/TimeLine' element={<TimeLine />} />
         <Route
           path='/developer-essential-skills'

--- a/src/Components/Frameworks.jsx
+++ b/src/Components/Frameworks.jsx
@@ -2,10 +2,24 @@ import { useEffect } from "react";
 import Card from "./cards/Card";
 import { Link, useLocation } from "react-router-dom";
 import useSEO from "./Hooks/useSEO";
+import List from "../Data/JS.json";
 
 const ProgLan = () => {
   const location = useLocation();
-  const { Frameworks } = location.state || { Frameworks: [] };
+  const { Frameworks: stateFrameworks = [] } = location.state || {};
+
+  const allFrameworks = List.flatMap((lang) =>
+    lang.More.map((fw) => ({ ...fw, Language: lang.Language }))
+  );
+
+  const frameworksData =
+    stateFrameworks.length > 0 ? stateFrameworks : allFrameworks;
+
+  const langFromQuery = new URLSearchParams(location.search).get("lang");
+
+  const groupedFrameworks = stateFrameworks.length > 0
+    ? [{ language: langFromQuery || "Frameworks", list: stateFrameworks }]
+    : List.map((lang) => ({ language: lang.Language, list: lang.More }));
 
   useSEO({
     title: "Frameworks Overview | CodeSphere",
@@ -83,20 +97,29 @@ const ProgLan = () => {
           </Link>
         </div>
       </div>
-      <div className='flex flex-wrap gap-4 justify-center items-center px-4 md:px-10 pb-10'>
-        {Frameworks.map((framework, index) => (
-          <Card
-            key={index} // Unique key for each framework
-            Title={framework.Framework}
-            Summary={framework.Summary}
-            URL={framework.URL}
-            Tools={framework.Tools}
-            Lib={framework.Libraries}
-            RTNIT={Frameworks}
-            PrevPath={location.pathname}
-          />
-        ))}
-      </div>
+      {groupedFrameworks.map(({ language, list }) => (
+        <div key={language} className='w-full'>
+          {groupedFrameworks.length > 1 && (
+            <h2 className='text-lg font-semibold text-center mt-8 mb-4'>
+              {language}
+            </h2>
+          )}
+          <div className='flex flex-wrap gap-4 justify-center items-center px-4 md:px-10 pb-10'>
+            {list.map((framework, index) => (
+              <Card
+                key={`${language}-${index}`}
+                Title={framework.Framework}
+                Summary={framework.Summary}
+                URL={framework.URL}
+                Tools={framework.Tools}
+                Lib={framework.Libraries}
+                RTNIT={frameworksData}
+                PrevPath={location.pathname}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
     </>
   );
 };

--- a/src/Components/Frameworks.jsx
+++ b/src/Components/Frameworks.jsx
@@ -105,9 +105,9 @@ const ProgLan = () => {
             </h2>
           )}
           <div className='flex flex-wrap gap-4 justify-center items-center px-4 md:px-10 pb-10'>
-            {list.map((framework, index) => (
+            {list.map((framework) => (
               <Card
-                key={`${language}-${index}`}
+                key={`${language}-${framework.Framework}`}
                 Title={framework.Framework}
                 Summary={framework.Summary}
                 URL={framework.URL}

--- a/src/Components/Tool_Lib.jsx
+++ b/src/Components/Tool_Lib.jsx
@@ -1,15 +1,36 @@
 import Tool_Lib_Card from "./cards/Tool_Lib_Card";
-import { useLocation, Link } from "react-router-dom";
+import { useLocation, Link, useParams } from "react-router-dom";
 import useSEO from "./Hooks/useSEO";
+import List from "../Data/JS.json";
 
 const Tool_Lib = () => {
   const location = useLocation();
+  const { frameworkName = "", type = "" } = useParams();
   const {
-    tools = [],
-    Libraries = [],
-    ReturnIT = [],
+    tools: stateTools = [],
+    Libraries: stateLibraries = [],
+    ReturnIT: stateReturn = [],
     PrevPath = "/Frameworks",
   } = location.state || {};
+
+  let tools = stateTools;
+  let Libraries = stateLibraries;
+  let ReturnIT = stateReturn;
+
+  if (tools.length === 0 && Libraries.length === 0 && frameworkName) {
+    const decoded = decodeURIComponent(frameworkName).toLowerCase();
+    const allFrameworks = List.flatMap((lang) =>
+      lang.More.map((fw) => ({ ...fw, Language: lang.Language }))
+    );
+    const match = allFrameworks.find(
+      (fw) => fw.Framework.toLowerCase() === decoded
+    );
+    if (match) {
+      tools = match.Tools || [];
+      Libraries = match.Libraries || [];
+    }
+    ReturnIT = allFrameworks;
+  }
 
   let printIt = [];
   let heading = "";
@@ -22,7 +43,7 @@ const Tool_Lib = () => {
   const libDef =
     "A framework's library refers to a collection of pre-written, reusable code or functions that a framework depends on or integrates with to provide specific functionalities. Libraries within a framework offer tools or utilities to perform common tasks like data manipulation, API calls, or user interface rendering.";
 
-  if (tools.length > 0) {
+  if (type === "tools") {
     printIt = tools;
     heading = "Tools";
     def = toolDef;
@@ -39,11 +60,15 @@ const Tool_Lib = () => {
     description: def,
     keywords:
       "AliHamza projects, thealihamza04 projects, programming language timeline, projramming lang time line",
-    canonical: "https://codes-sphere.vercel.app/Frameworks/ToLib",
+    canonical: `https://codes-sphere.vercel.app/Frameworks/${encodeURIComponent(
+      frameworkName
+    )}/${type}`,
     og: {
       title: `${heading} for Frameworks | CodeSphere`,
       description: def,
-      url: "https://codes-sphere.vercel.app/Frameworks/ToLib",
+      url: `https://codes-sphere.vercel.app/Frameworks/${encodeURIComponent(
+        frameworkName
+      )}/${type}`,
       type: "website",
     },
     twitter: {
@@ -58,7 +83,9 @@ const Tool_Lib = () => {
           "@type": "Service",
           name: `${heading} for Frameworks`,
           provider: { "@type": "Organization", name: "CodeSphere" },
-          url: "https://codes-sphere.vercel.app/Frameworks/ToLib",
+          url: `https://codes-sphere.vercel.app/Frameworks/${encodeURIComponent(
+            frameworkName
+          )}/${type}`,
         },
         {
           "@type": "BreadcrumbList",
@@ -79,7 +106,9 @@ const Tool_Lib = () => {
               "@type": "ListItem",
               position: 3,
               name: crumbName,
-              item: "https://codes-sphere.vercel.app/Frameworks/ToLib",
+              item: `https://codes-sphere.vercel.app/Frameworks/${encodeURIComponent(
+                frameworkName
+              )}/${type}`,
             },
           ],
         },
@@ -110,9 +139,9 @@ const Tool_Lib = () => {
       </div>
 
       <div className='flex flex-wrap gap-4 justify-center items-center px-4 pb-5 md:px-10'>
-        {printIt.map((Item, index) => (
+        {printIt.map((Item) => (
           <Tool_Lib_Card
-            key={index}
+            key={Item.Name}
             Name={Item.Name}
             Summary={Item.Summary}
             URL={Item.URL}

--- a/src/Components/cards/Card.jsx
+++ b/src/Components/cards/Card.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-const Card = ({ Title, Summary, URL, Tools, Lib, RTNIT }) => {
+const Card = ({ Title, Summary, URL, Tools, Lib, RTNIT, PrevPath }) => {
   return (
     <>
       <div className="w-full sm:w-80 pt-5 rounded-xl cursor-default">
@@ -23,15 +23,15 @@ const Card = ({ Title, Summary, URL, Tools, Lib, RTNIT }) => {
             <div className="card-actions justify-end mt-1">
               <Link
                 className="text-[10px] border-[1px] px-[10px] border-blue-500 p-1 rounded-full text-blue-500 font-medium"
-                to="ToLib"
-                state={{ tools: Tools, ReturnIT: RTNIT }}
+                to={`/Frameworks/${encodeURIComponent(Title)}/tools`}
+                state={{ tools: Tools, ReturnIT: RTNIT, PrevPath }}
               >
                 Tools
               </Link>
               <Link
                 className="text-[10px] px-[10px]   bg-blue-500 p-1 rounded-full text-white font-medium"
-                to="ToLib"
-                state={{ Libraries: Lib, ReturnIT: RTNIT }}
+                to={`/Frameworks/${encodeURIComponent(Title)}/libraries`}
+                state={{ Libraries: Lib, ReturnIT: RTNIT, PrevPath }}
               >
                 Lib
               </Link>


### PR DESCRIPTION
## Summary
- load all frameworks from data when no navigation state is present
- group frameworks by language and render their tool/library links

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 'React' is defined but never used; ... etc.)

------
https://chatgpt.com/codex/tasks/task_e_68a7fbdce214832b96c7fc4a5d4ec89e