### PR TITLE
Add beginner AI/ML/DL guide

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Analytics } from "@vercel/analytics/react";
 import {
   BrowserRouter as Router,
@@ -11,6 +10,7 @@ import Tool_Lib from "./Components/Tool_Lib";
 import Languages from "./Components/Languages";
 import TimeLine from "./Components/TimeLine.jsx";
 import VersionControl from "./Components/VersionControl";
+import AIMLDL from "./Components/AIMLDL";
 import Footer from "./Components/Footer.jsx";
 import { Toaster } from "react-hot-toast";
 
@@ -33,6 +33,7 @@ const Layout = () => {
           path='/developer-essential-skills'
           element={<VersionControl />}
         />
+        <Route path='/ai-ml-dl' element={<AIMLDL />} />
         <Route path='*' element={<div>Not Found</div>} />
       </Routes>
       {!hideFooter && <Footer />}

--- a/src/Components/AIMLDL.jsx
+++ b/src/Components/AIMLDL.jsx
@@ -1,0 +1,76 @@
+/* eslint-disable react-refresh/only-export-components */
+import { useEffect } from "react";
+import useSEO from "./Hooks/useSEO";
+
+const AIMLDL = () => {
+  useSEO({
+    title: "AI / ML / DL for Beginners | CodeSphere",
+    description:
+      "Introductory guide explaining the basics of Artificial Intelligence, Machine Learning and Deep Learning.",
+    keywords:
+      "AI basics, machine learning overview, deep learning introduction, CodeSphere",
+    canonical: "https://codes-sphere.vercel.app/ai-ml-dl",
+    og: {
+      title: "AI / ML / DL for Beginners | CodeSphere",
+      description:
+        "Introductory guide explaining the basics of Artificial Intelligence, Machine Learning and Deep Learning.",
+      url: "https://codes-sphere.vercel.app/ai-ml-dl",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: "AI / ML / DL for Beginners | CodeSphere",
+      description:
+        "Introductory guide explaining the basics of Artificial Intelligence, Machine Learning and Deep Learning.",
+    },
+    structuredData: {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      name: "AI / ML / DL for Beginners",
+      url: "https://codes-sphere.vercel.app/ai-ml-dl",
+    },
+  });
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "instant" });
+  }, []);
+
+  const topics = [
+    {
+      title: "Artificial Intelligence",
+      summary:
+        "AI is the science of making machines perform tasks that typically require human intelligence such as reasoning or problem solving.",
+    },
+    {
+      title: "Machine Learning",
+      summary:
+        "Machine learning enables systems to learn from data and improve their performance without being explicitly programmed.",
+    },
+    {
+      title: "Deep Learning",
+      summary:
+        "Deep learning is a subset of machine learning that uses multi-layered neural networks to model complex patterns in data.",
+    },
+  ];
+
+  return (
+    <div className='min-h-screen bg-gray-100 py-9 px-4 md:px-20 space-y-6'>
+      <h1 className='heading'>AI / ML / DL Basics</h1>
+      <p className='text-sm tracking-wider text-justify leading-relaxed opacity-70'>
+        This beginner friendly guide introduces core concepts behind artificial intelligence, machine learning and deep learning.
+      </p>
+      <div className='flex flex-col gap-6'>
+        {topics.map((topic) => (
+          <div key={topic.title} className='bg-white shadow rounded-lg p-4 space-y-2'>
+            <h2 className='text-lg font-semibold'>{topic.title}</h2>
+            <p className='text-sm tracking-wider leading-relaxed opacity-70'>
+              {topic.summary}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AIMLDL;

--- a/src/Components/AIMLDL.jsx
+++ b/src/Components/AIMLDL.jsx
@@ -40,16 +40,31 @@ const AIMLDL = () => {
       title: "Artificial Intelligence",
       summary:
         "AI is the science of making machines perform tasks that typically require human intelligence such as reasoning or problem solving.",
+      roadmap: [
+        "Learn programming fundamentals and logic",
+        "Explore search, knowledge representation and planning",
+        "Build small AI projects like chatbots or game agents",
+      ],
     },
     {
       title: "Machine Learning",
       summary:
         "Machine learning enables systems to learn from data and improve their performance without being explicitly programmed.",
+      roadmap: [
+        "Study statistics, probability and linear algebra",
+        "Understand supervised and unsupervised learning",
+        "Practice with libraries such as scikit-learn or TensorFlow",
+      ],
     },
     {
       title: "Deep Learning",
       summary:
         "Deep learning is a subset of machine learning that uses multi-layered neural networks to model complex patterns in data.",
+      roadmap: [
+        "Review neural network fundamentals",
+        "Dive into architectures like CNNs and RNNs",
+        "Experiment with frameworks such as PyTorch",
+      ],
     },
   ];
 
@@ -66,6 +81,12 @@ const AIMLDL = () => {
             <p className='text-sm tracking-wider leading-relaxed opacity-70'>
               {topic.summary}
             </p>
+            <h3 className='text-sm font-medium mt-2'>Roadmap</h3>
+            <ul className='list-disc list-inside text-sm tracking-wider leading-relaxed opacity-70 space-y-1'>
+              {topic.roadmap.map((step) => (
+                <li key={step}>{step}</li>
+              ))}
+            </ul>
           </div>
         ))}
       </div>

--- a/src/Components/Footer.jsx
+++ b/src/Components/Footer.jsx
@@ -59,6 +59,9 @@ const Footer = () => {
           <Link to={"/Frameworks"} className='link link-hover '>
             Frameworks
           </Link>
+          <Link to={"/ai-ml-dl"} className='link link-hover '>
+            AI / ML / DL
+          </Link>
           <Link to={"/developer-essential-skills"} className='link link-hover '>
             Why Matters
           </Link>


### PR DESCRIPTION
## Summary
- introduce AI/ML/DL basics page with brief explanations for each field
- wire up `/ai-ml-dl` route and footer link to access the new guide

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint src/App.jsx src/Components/Footer.jsx src/Components/AIMLDL.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68a8012cf5d4832b9a5d45a4ecfe9234