### PR TITLE
feat: add animated chatgpt-style theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,11 @@
 <!doctype html>
-<html lang="en" data-theme="light">
+<html lang="en">
 
 <head>
+  <script>
+    const storedTheme = localStorage.getItem('theme') || 'light';
+    document.documentElement.setAttribute('data-theme', storedTheme);
+  </script>
   <meta charset="UTF-8" />
   <link rel="icon" href="https://fonts.gstatic.com/s/i/materialicons/code/v1/24px.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -51,7 +55,7 @@
   <title>CodeSphere</title>
 </head>
 
-<body>
+<body class="bg-base-100 text-base-content transition-colors duration-300">
   <div id="root"></div>
   <script type="module" src="/src/main.jsx"></script>
 </body>

--- a/src/Components/ThemeToggle.jsx
+++ b/src/Components/ThemeToggle.jsx
@@ -16,11 +16,17 @@ const ThemeToggle = () => {
 
   return (
     <button
-      className="btn btn-ghost fixed top-4 right-4 z-50"
+      className="btn btn-ghost fixed top-4 right-4 z-50 transition-transform duration-300"
       onClick={toggleTheme}
       aria-label="Toggle Theme"
     >
-      {theme === "light" ? "🌙" : "☀️"}
+      <span
+        className={`inline-block transition-transform duration-300 ${
+          theme === "light" ? "rotate-0" : "rotate-180"
+        }`}
+      >
+        {theme === "light" ? "🌙" : "☀️"}
+      </span>
     </button>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -17,4 +17,5 @@
 html{
     overflow-y: scroll;
     overflow-x: hidden;
+    transition: background-color 0.3s ease, color 0.3s ease;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,15 +17,21 @@ export default {
   daisyui: {
     themes: [
       {
-        light: { ...themes["light"] },
+        light: {
+          ...themes["light"],
+          "base-100": "#ffffff",
+          "base-200": "#f7f7f8",
+          "base-300": "#e5e5e5",
+          "base-content": "#202123",
+        },
       },
       {
         dark: {
           ...themes["dark"],
-          "base-100": "#000000",
-          "base-200": "#0a0a0a",
-          "base-300": "#171717",
-          "base-content": "#ffffff",
+          "base-100": "#343541",
+          "base-200": "#444654",
+          "base-300": "#565869",
+          "base-content": "#ececf1",
         },
       },
     ],


### PR DESCRIPTION
## Summary
- add ChatGPT-inspired light and dark color palettes
- animate theme toggle and smooth page transitions
- persist theme selection across reloads

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaa7358558832b86afe8b3a3566805