### PR TITLE
feat: add custom spacing scale

### DIFF
--- a/src/Components/Footer.jsx
+++ b/src/Components/Footer.jsx
@@ -47,7 +47,7 @@ const Footer = () => {
 
   return (
     <div className='bg-base-200'>
-      <footer className='footer  text-base-content p-10 container mx-auto'>
+      <footer className='footer  text-base-content p-2xl container mx-auto'>
         <nav>
           <h6 className='footer-title'>Services</h6>
           <Link to={"/"} className='link link-hover '>
@@ -68,20 +68,20 @@ const Footer = () => {
         </nav>
         <nav>
           <h6 className='footer-title'>Social</h6>
-          <div className='grid grid-flow-col gap-4'>
+          <div className='grid grid-flow-col gap-md'>
             <a
               className='fill-current'
               target='_blank'
               href='https://www.linkedin.com/in/contact-with-alihamza'
             >
-              <FaLinkedinIn className='size-5' />
+              <FaLinkedinIn className='size-lg' />
             </a>
             <a
               className='fill-current'
               target='_blank'
               href='https://github.com/thealihamza04'
             >
-              <PiGithubLogoDuotone className='size-6' />
+              <PiGithubLogoDuotone className='size-lg' />
             </a>
             <a
               href='https://mail.google.com/mail/?view=cm&fs=1&to=ah0681988@gmail.com'
@@ -89,14 +89,14 @@ const Footer = () => {
               rel='noopener noreferrer'
               className='fill-current'
             >
-              <SiGmail className='size-5' />
+              <SiGmail className='size-lg' />
             </a>
           </div>
         </nav>
         <form onSubmit={sendFeedback}>
           <h6 className='footer-title '>FeedBack</h6>
-          <fieldset className='w-92 space-y-2'>
-            <div className='flex flex-row gap-3'>
+          <fieldset className='w-92 space-y-sm'>
+            <div className='flex flex-row gap-sm'>
               <input
                 id='name'
                 type='text'
@@ -128,7 +128,7 @@ const Footer = () => {
               </button>
             </div>
             <textarea
-              className='input input-lg focus:outline-none text-xs py-2 px-2 resize-none w-full '
+              className='input input-lg focus:outline-none text-xs py-sm px-sm resize-none w-full '
               rows={3}
               id='message'
               onChange={(e) =>

--- a/src/Components/Frameworks.jsx
+++ b/src/Components/Frameworks.jsx
@@ -80,15 +80,15 @@ const ProgLan = () => {
 
   return (
     <>
-      <div className='py-9 px-4 space-y-6 bg-base-100'>
+      <div className='py-2xl px-md space-y-lg bg-base-100'>
         <h1 className='heading'>Frameworks</h1>
-        <div className='px-4 md:px-48'>
+        <div className='px-md md:px-7xl'>
           <hr className='border-base-content' />
         </div>
-        <p className='px-4 md:px-20 text-sm font-normal text-justify leading-relaxed tracking-wide text-base-content/80'>
+        <p className='px-md md:px-5xl text-sm font-normal text-justify leading-relaxed tracking-wide text-base-content/80'>
           {def}
         </p>
-        <div className='flex justify-center mt-8'>
+        <div className='flex justify-center mt-xl'>
           <Link
             className='btn btn-outline no-animation text-sm md:text-base'
             to='/'
@@ -100,11 +100,11 @@ const ProgLan = () => {
       {groupedFrameworks.map(({ language, list }) => (
         <div key={language} className='w-full'>
           {groupedFrameworks.length > 1 && (
-            <h2 className='text-lg font-semibold text-center mt-8 mb-4'>
+            <h2 className='text-lg font-semibold text-center mt-xl mb-md'>
               {language}
             </h2>
           )}
-          <div className='flex flex-wrap gap-4 justify-center items-center px-4 md:px-10 pb-10'>
+          <div className='flex flex-wrap gap-md justify-center items-center px-md md:px-2xl pb-2xl'>
             {list.map((framework) => (
               <Card
                 key={`${language}-${framework.Framework}`}

--- a/src/Components/Languages.jsx
+++ b/src/Components/Languages.jsx
@@ -44,22 +44,22 @@ const Languages = () => {
       className={`relative min-h-screen bg-base-100   motion-opacity-in-[0%] motion-blur-in-[40px] motion-ease-spring-snappy`}
     >
       {/* Header Section */}
-      <div className='relative py-9 mx-2 md:mx-8 lg:mx-16 space-y-6 z-10'>
+      <div className='relative py-2xl mx-sm md:mx-xl lg:mx-4xl space-y-lg z-10'>
         <h1 className='heading'>Programming Languages</h1>
-        <div className='px-4 md:px-48'>
+        <div className='px-md md:px-7xl'>
           <hr className='border-base-content' />
         </div>
-        <p className='px-4 md:px-20 text-sm tracking-wider text-justify leading-relaxed text-base-content/70'>
+        <p className='px-md md:px-5xl text-sm tracking-wider text-justify leading-relaxed text-base-content/70'>
           {def}
         </p>
-        <p className='px-4 md:px-20 text-sm tracking-wider text-justify leading-relaxed text-base-content/70'>
+        <p className='px-md md:px-5xl text-sm tracking-wider text-justify leading-relaxed text-base-content/70'>
           Discover AliHamza projects, thealihamza04 repositories and a programming
           language time line in this community-driven guide.
         </p>
       </div>
 
       {/* Language Cards */}
-      <div className='flex flex-wrap gap-6 justify-center items-center px-4 md:px-10 lg:px-8 pb-10'>
+      <div className='flex flex-wrap gap-lg justify-center items-center px-md md:px-2xl lg:px-xl pb-2xl'>
         {List.map((Language, index) => (
           <LanCard
             key={index}

--- a/src/Components/MLRoadmap.jsx
+++ b/src/Components/MLRoadmap.jsx
@@ -63,14 +63,14 @@ const MLRoadmap = () => {
   }, []);
 
   return (
-    <div className='min-h-screen px-12 py-20 overflow-x-hidden'>
-      <h1 className='text-4xl font-bold py-12 text-center'>Machine Learning Roadmap</h1>
+    <div className='min-h-screen px-3xl py-5xl overflow-x-hidden'>
+      <h1 className='text-4xl font-bold py-3xl text-center'>Machine Learning Roadmap</h1>
       <div>
         <ul className='flex flex-col justify-center items-center'>
           {Object.entries(mlRoadmap).map(([topic, info], index) => (
             <li
               key={index}
-              className={`min-w-52 md:min-w-60 my-1 ${
+              className={`min-w-52 md:min-w-60 my-xs ${
                 isInView
                   ? "motion-translate-x-in-[0%] motion-translate-y-in-[95%]"
                   : ""

--- a/src/Components/ThemeToggle.jsx
+++ b/src/Components/ThemeToggle.jsx
@@ -16,7 +16,7 @@ const ThemeToggle = () => {
 
   return (
     <button
-      className="btn btn-ghost fixed top-4 right-4 z-50 transition-transform duration-300"
+      className="btn btn-ghost fixed top-md right-md z-50 transition-transform duration-300"
       onClick={toggleTheme}
       aria-label="Toggle Theme"
     >

--- a/src/Components/TimeLine.jsx
+++ b/src/Components/TimeLine.jsx
@@ -64,8 +64,8 @@ const TimeLine = () => {
 
   return (
     <>
-      <div className=' min-h-screen px-12 py-20 overflow-x-hidden'>
-        <h1 className='text-4xl font-bold py-12 text-center'>
+      <div className=' min-h-screen px-3xl py-5xl overflow-x-hidden'>
+        <h1 className='text-4xl font-bold py-3xl text-center'>
           The TimeLine of Languages
         </h1>
         <div>
@@ -74,7 +74,7 @@ const TimeLine = () => {
               ([language, info], index) => (
                 <li
                   key={index}
-                  className={`min-w-52 md:min-w-60  my-1  ${
+                  className={`min-w-52 md:min-w-60  my-xs  ${
                     isInView
                       ? "motion-translate-x-in-[0%] motion-translate-y-in-[95%] "
                       : ""
@@ -86,7 +86,7 @@ const TimeLine = () => {
                   // className={`bg-gray-700 opacity-50 w-1 px rounded-full  ml-[43.9%] md:ml-[42.3%] `}
                   // style={{ minHeight: `${info.gap * 20}px` }}
                   />
-                  {/* <div className='flex flex-row gap-5 '>
+                  {/* <div className='flex flex-row gap-lg '>
                     <h1 className='min-w-[25%]  '>{info.released}</h1>
                     <MdCircle className='min-w-[20%] text-3xl text-slate-700 opacity-45' />{" "}
                     <h1 className='min-w-[50%] '>{language}</h1>

--- a/src/Components/Tool_Lib.jsx
+++ b/src/Components/Tool_Lib.jsx
@@ -118,27 +118,27 @@ const Tool_Lib = () => {
 
   return (
     <>
-      <div className='py-9 px-4 pd:px-10 space-y-6 bg-base-100'>
+      <div className='py-2xl px-md md:px-2xl space-y-lg bg-base-100'>
         <h1 className='heading'>{heading}</h1>
-        <div className='px-4 md:px-48'>
+        <div className='px-md md:px-7xl'>
           <hr className='border-base-content' />
         </div>
-        <p className='px-4 md:px-20 text-sm font-normal tracking-wide text-justify leading-relaxed text-base-content/80'>
+        <p className='px-md md:px-5xl text-sm font-normal tracking-wide text-justify leading-relaxed text-base-content/80'>
           {def}
         </p>
 
-        <div className='flex justify-center mt-6'>
+        <div className='flex justify-center mt-lg'>
           <Link
             to={PrevPath}
             state={{ Frameworks: ReturnIT }}
-            className='btn btn-outline text-sm md:text-base px-4 py-2'
+            className='btn btn-outline text-sm md:text-base px-md py-sm'
           >
             Back
           </Link>
         </div>
       </div>
 
-      <div className='flex flex-wrap gap-4 justify-center items-center px-4 pb-5 md:px-10'>
+      <div className='flex flex-wrap gap-md justify-center items-center px-md pb-lg md:px-2xl'>
         {printIt.map((Item) => (
           <Tool_Lib_Card
             key={Item.Name}

--- a/src/Components/VersionControl.jsx
+++ b/src/Components/VersionControl.jsx
@@ -199,11 +199,11 @@ const AccordionGroup = () => {
 
   return (
     <>
-      <div className='spacey-y-24 container mx-auto py-12'>
-        <h1 className='text-3xl md:text-3xl font-extrabold py-12 text-center'>
+      <div className='space-y-6xl container mx-auto py-3xl'>
+        <h1 className='text-3xl md:text-3xl font-extrabold py-3xl text-center'>
           Essential Questions Every Developer Should Know
         </h1>
-        <div className='join join-vertical w-full space-y-4'>
+        <div className='join join-vertical w-full space-y-md'>
           {items.map((item, index) => (
             <AccordionItem
               key={index}

--- a/src/Components/cards/Card.jsx
+++ b/src/Components/cards/Card.jsx
@@ -4,15 +4,15 @@ import PropTypes from "prop-types";
 const Card = ({ Title, Summary, URL, Tools, Lib, RTNIT, PrevPath }) => {
   return (
     <>
-      <div className="w-full sm:w-80 pt-5 rounded-xl cursor-default">
+      <div className="w-full sm:w-80 pt-lg rounded-xl cursor-default">
         <div className="card bg-base-200 shadow-sm border border-base-300 text-base-content hover:shadow-md transition-all duration-500 ease-linear">
           <div className="card-body">
             <h2 className="card-title font-bold text-2xl">{Title}</h2>
-            <p className="text-[13px] text-base-content/80 mt-2">
+            <p className="text-[13px] text-base-content/80 mt-sm">
               {Summary}
             </p>
             <a
-              className="text-base-content/25 mt-0 break-words text-xs delay-75"
+              className="text-base-content/25 break-words text-xs delay-75"
               href={URL}
               target="_blank"
               rel="noopener noreferrer"
@@ -20,16 +20,16 @@ const Card = ({ Title, Summary, URL, Tools, Lib, RTNIT, PrevPath }) => {
               <span className="text-center">Open</span>
             </a>
 
-            <div className="card-actions justify-end mt-1">
+            <div className="card-actions justify-end mt-xs">
               <Link
-                className="text-[10px] border px-[10px] border-blue-500 p-1 rounded-full text-blue-500 font-medium"
+                className="text-[10px] border px-sm border-blue-500 p-xs rounded-full text-blue-500 font-medium"
                 to={`/Frameworks/${encodeURIComponent(Title)}/tools`}
                 state={{ tools: Tools, ReturnIT: RTNIT, PrevPath }}
               >
                 Tools
               </Link>
               <Link
-                className="text-[10px] px-[10px] bg-blue-500 p-1 rounded-full text-white font-medium"
+                className="text-[10px] px-sm bg-blue-500 p-xs rounded-full text-white font-medium"
                 to={`/Frameworks/${encodeURIComponent(Title)}/libraries`}
                 state={{ Libraries: Lib, ReturnIT: RTNIT, PrevPath }}
               >

--- a/src/Components/cards/LanCard.jsx
+++ b/src/Components/cards/LanCard.jsx
@@ -3,14 +3,14 @@ import PropTypes from "prop-types";
 
 const LanCard = ({ Title, Summary, Details }) => {
   return (
-    <div className='w-full md:w-80 mt-5 rounded-xl cursor-default group z-30'>
+    <div className='w-full md:w-80 mt-lg rounded-xl cursor-default group z-30'>
       <div className='card bg-base-200 border border-base-300 text-base-content transition-all duration-300 ease-in-out'>
         <div className='card-body'>
           <h2 className='card-title font-bold text-2xl'>{Title}</h2>
-          <p className='text-[14px] text-base-content/80 mt-2 break-words'>{Summary}</p>
-          <div className='card-actions justify-end mt-2'>
+          <p className='text-[14px] text-base-content/80 mt-sm break-words'>{Summary}</p>
+          <div className='card-actions justify-end mt-sm'>
             <Link
-              className='text-[10px] px-[12px] bg-blue-500 p-1 rounded-full text-white font-[400]'
+              className='text-[10px] px-md bg-blue-500 p-xs rounded-full text-white font-[400]'
               to={`/Frameworks?lang=${encodeURIComponent(Title)}`}
               state={{ Frameworks: Details }}
             >

--- a/src/Components/cards/TimeLine/TimeLineCard.jsx
+++ b/src/Components/cards/TimeLine/TimeLineCard.jsx
@@ -10,7 +10,7 @@ const TimeLineCard = ({ released, language, description }) => {
   return (
     <motion.div ref={ref} initial={{ opacity: 0 }} whileInView={{ opacity: 1 }}>
       <div
-        className={`flex flex-row gap-5 ${
+        className={`flex flex-row gap-lg ${
           isInView
             ? "motion-scale-in-[0.3] motion-translate-x-in-[90%] motion-translate-y-in-[93%] motion-opacity-in-[50%] motion-rotate-in-[-29deg] motion-ease-spring-smooth"
             : ""
@@ -21,7 +21,7 @@ const TimeLineCard = ({ released, language, description }) => {
         <h1 className='min-w-[50%]'>{language}</h1>
       </div>
       {description && (
-        <p className='ml-[45%] md:ml-[43%] mt-2 text-xs text-base-content/50 max-w-xs'>
+        <p className='ml-[45%] md:ml-[43%] mt-sm text-xs text-base-content/50 max-w-xs'>
           {description}
         </p>
       )}

--- a/src/Components/cards/Tool_Lib_Card.jsx
+++ b/src/Components/cards/Tool_Lib_Card.jsx
@@ -3,15 +3,15 @@ import PropTypes from "prop-types";
 const Tool_Lib_Card = ({ Name, Summary, URL }) => {
   return (
     <>
-      <div className="w-full sm:w-80 pt-5 last:pb-5 rounded-xl cursor-default">
+      <div className="w-full sm:w-80 pt-lg last:pb-lg rounded-xl cursor-default">
         <div className="card bg-base-200 shadow-sm border border-base-300 text-base-content hover:shadow-md  transition-all duration-500 ease-linear">
           <div className="card-body">
             <h2 className="card-title font-bold text-2xl">{Name}</h2>
-            <p className="text-[13px] text-base-content/80 mt-2">
+            <p className="text-[13px] text-base-content/80 mt-sm">
               {Summary}
             </p>
             <a
-              className="text-base-content/25 mt-0 break-words text-xs delay-75"
+              className="text-base-content/25 break-words text-xs delay-75"
               href={URL}
               target="_blank"
               rel="noopener noreferrer"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,13 +5,28 @@ import themes from "daisyui/src/theming/themes.js";
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
+    spacing: {
+      0: "0px",
+      xs: "0.25rem",
+      sm: "0.5rem",
+      md: "1rem",
+      lg: "1.5rem",
+      xl: "2rem",
+      "2xl": "2.5rem",
+      "3xl": "3rem",
+      "4xl": "4rem",
+      "5xl": "5rem",
+      "6xl": "6rem",
+      "7xl": "12rem",
+      "52": "13rem",
+      "60": "15rem",
+      "80": "20rem",
+    },
     extend: {
       fontFamily: {
         sans: ['Roboto', 'sans-serif'],
       },
-    }
-
-
+    },
   },
   plugins: [daisyui, tailwindcssMotion],
   daisyui: {


### PR DESCRIPTION
## Summary
- replace Tailwind spacing utilities with custom scale for more uniform layout
- update all components to use new spacing tokens

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: flattenColorPalette is not a function)

------
https://chatgpt.com/codex/tasks/task_e_68abfb23a2b0832bb0e067d9a18d20b3